### PR TITLE
EC2からパブリックIPv4を削除

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -24,7 +24,7 @@ resource "aws_instance" "web" {
   ami                         = "ami-027fff96cc515f7bc" // Amazon Linux 2023
   instance_type               = var.instance_type
   subnet_id                   = aws_subnet.public_a.id
-  associate_public_ip_address = true
+  associate_public_ip_address = false
   vpc_security_group_ids      = [aws_security_group.default.id, aws_security_group.ec2.id]
   key_name                    = aws_key_pair.main.key_name
   user_data                   = <<-EOF


### PR DESCRIPTION
## 概要
EC2インスタンスにパブリックIPv4が割り当てられないように設定を変更しました。

## 変更内容
- `compute.tf`の`associate_public_ip_address`を`true`から`false`に変更

## 背景
composer対応については一時的なIPv4付与で行うため、EC2インスタンスに永続的なパブリックIPv4は不要です。

Close #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)