### PR TITLE
変数名変更: delegated_domain→zone_domain、sub_domain→app_domain

### DIFF
--- a/acm.tf
+++ b/acm.tf
@@ -1,7 +1,7 @@
 # 東京リージョン用のACM証明書
 resource "aws_acm_certificate" "tokyo" {
   provider          = aws.tokyo
-  domain_name       = var.sub_domain
+  domain_name       = var.app_domain
   validation_method = "DNS"
   tags = {
     Name = "terra-acm-tokyo"
@@ -35,7 +35,7 @@ resource "aws_route53_record" "tokyo_cert_validation" {
 # バージニアリージョン用のACM証明書
 resource "aws_acm_certificate" "virginia" {
   provider          = aws.virginia
-  domain_name       = var.sub_domain
+  domain_name       = var.app_domain
   validation_method = "DNS"
   tags = {
     Name = "terra-acm-virginia"

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -4,7 +4,7 @@ resource "aws_cloudfront_distribution" "web" {
   enabled             = true
   is_ipv6_enabled     = true
   comment             = "terra-cloudfront"
-  aliases             = [var.sub_domain]
+  aliases             = [var.app_domain]
   default_root_object = ""
   origin {
     domain_name = aws_lb.web.dns_name
@@ -19,7 +19,7 @@ resource "aws_cloudfront_distribution" "web" {
   logging_config {
     bucket          = aws_s3_bucket.log.bucket_regional_domain_name
     include_cookies = false
-    prefix          = "cloudfront-${var.sub_domain}/"
+    prefix          = "cloudfront-${var.app_domain}/"
   }
   default_cache_behavior {
     allowed_methods            = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]

--- a/route53.tf
+++ b/route53.tf
@@ -1,13 +1,13 @@
 # Route53ゾーンIDを自動取得(ゾーン名から)
 data "aws_route53_zone" "delegated" {
-  name         = var.delegated_domain
+  name         = var.zone_domain
   private_zone = false
 }
 
-# サブドメイン用Route53レコード(CloudFront用)
-resource "aws_route53_record" "sub_domain_cloudfront" {
+# アプリケーションドメイン用Route53レコード(CloudFront用)
+resource "aws_route53_record" "app_cloudfront" {
   zone_id = data.aws_route53_zone.delegated.zone_id
-  name    = var.sub_domain
+  name    = var.app_domain
   type    = "A"
   alias {
     name                   = aws_cloudfront_distribution.web.domain_name

--- a/s3.tf
+++ b/s3.tf
@@ -1,7 +1,7 @@
 # CloudFrontログ保存用S3バケット
 resource "aws_s3_bucket" "log" {
   provider      = aws.tokyo
-  bucket        = "log-${var.sub_domain}"
+  bucket        = "log-${var.app_domain}"
   force_destroy = true
   tags = {
     Name = "terra-log"

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,9 @@
-variable "delegated_domain" {
+variable "zone_domain" {
   description = "The domain name to delegate"
   type        = string
 }
 
-variable "sub_domain" {
+variable "app_domain" {
   description = "The domain name to delegate"
   type        = string
 }


### PR DESCRIPTION
## 変更内容

- `delegated_domain` → `zone_domain` に変数名を変更
- `sub_domain` → `app_domain` に変数名を変更

対象ファイル: `variables.tf`, `route53.tf`, `acm.tf`, `s3.tf`, `cloudfront.tf`, `terraform.tfvars`

Close #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 別途人力対応
- 設定名を調整
```
-# サブドメイン用Route53レコード(CloudFront用)
-resource "aws_route53_record" "sub_domain_cloudfront" {
+# アプリケーションドメイン用Route53レコード(CloudFront用)
+resource "aws_route53_record" "app_cloudfront" {
```