### PR TITLE
tags指定削除・default_tagsに一元化

### DIFF
--- a/acm.tf
+++ b/acm.tf
@@ -3,9 +3,6 @@ resource "aws_acm_certificate" "tokyo" {
   provider          = aws.tokyo
   domain_name       = var.app_domain
   validation_method = "DNS"
-  tags = {
-    Name = "terra-acm-tokyo"
-  }
 }
 
 # 東京リージョン用ACM証明書のDNS検証
@@ -37,9 +34,6 @@ resource "aws_acm_certificate" "virginia" {
   provider          = aws.virginia
   domain_name       = var.app_domain
   validation_method = "DNS"
-  tags = {
-    Name = "terra-acm-virginia"
-  }
 }
 
 # バージニアリージョン用ACM証明書のDNS検証
@@ -54,9 +48,6 @@ resource "aws_acm_certificate" "image" {
   provider          = aws.virginia
   domain_name       = var.image_domain
   validation_method = "DNS"
-  tags = {
-    Name = "terra-acm-image"
-  }
 }
 
 resource "aws_route53_record" "image_cert_validation" {

--- a/backend-resources.tf
+++ b/backend-resources.tf
@@ -6,10 +6,6 @@ resource "aws_s3_bucket" "terraform_state" {
   # 誤って削除されないように保護（本番環境では true を推奨）
   force_destroy = true
 
-  tags = {
-    Name        = "terraform-state"
-    Description = "Terraform state storage"
-  }
 }
 
 # バージョニング有効化（状態ファイルの履歴を保持）

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -42,9 +42,6 @@ resource "aws_cloudfront_distribution" "web" {
     }
   }
   price_class = "PriceClass_200"
-  tags = {
-    Name = "terra-cloudfront"
-  }
 }
 
 # CloudFront OAC(画像用S3バケット・本番)
@@ -109,9 +106,6 @@ resource "aws_cloudfront_distribution" "image" {
   }
   price_class = "PriceClass_200"
   depends_on  = [aws_acm_certificate_validation.image, aws_s3_bucket_acl.image]
-  tags = {
-    Name = "terra-image-cloudfront"
-  }
 }
 
 # CloudFrontキャッシュポリシー(1秒TTL)

--- a/compute.tf
+++ b/compute.tf
@@ -3,9 +3,6 @@ resource "aws_ec2_instance_connect_endpoint" "main" {
   provider           = aws.tokyo
   subnet_id          = aws_subnet.public_a.id
   security_group_ids = [aws_security_group.default.id]
-  tags = {
-    Name = "terra-ec2-ice"
-  }
 }
 
 # EC2用キーペア
@@ -13,9 +10,6 @@ resource "aws_key_pair" "main" {
   provider   = aws.tokyo
   key_name   = "terra-key"
   public_key = var.public_key
-  tags = {
-    Name = "terra-key"
-  }
 }
 
 # EC2インスタンス
@@ -34,7 +28,4 @@ resource "aws_instance" "web" {
     sudo systemctl enable nginx
     sudo systemctl start nginx
   EOF
-  tags = {
-    Name = "terra-ec2"
-  }
 }

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -6,9 +6,6 @@ resource "aws_lb" "web" {
   load_balancer_type = "application"
   subnets            = [aws_subnet.public_a.id, aws_subnet.public_c.id]
   security_groups    = [aws_security_group.default.id, aws_security_group.elb.id]
-  tags = {
-    Name = "terra-elb"
-  }
 }
 
 # ELBターゲットグループ
@@ -26,9 +23,6 @@ resource "aws_lb_target_group" "web" {
     timeout             = 5
     healthy_threshold   = 2
     unhealthy_threshold = 2
-  }
-  tags = {
-    Name = "terra-tg"
   }
 }
 

--- a/network.tf
+++ b/network.tf
@@ -5,9 +5,6 @@ resource "aws_vpc" "main" {
   assign_generated_ipv6_cidr_block = true
   enable_dns_support               = true
   enable_dns_hostnames             = true
-  tags = {
-    Name = "terra-vpc"
-  }
 }
 
 # サブネットA
@@ -19,9 +16,6 @@ resource "aws_subnet" "public_a" {
   map_public_ip_on_launch         = false
   ipv6_cidr_block                 = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, 0)
   assign_ipv6_address_on_creation = true
-  tags = {
-    Name = "terra-subnet-a"
-  }
 }
 
 # サブネットC
@@ -33,36 +27,24 @@ resource "aws_subnet" "public_c" {
   map_public_ip_on_launch         = false
   ipv6_cidr_block                 = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, 1)
   assign_ipv6_address_on_creation = true
-  tags = {
-    Name = "terra-subnet-c"
-  }
 }
 
 # インターネットゲートウェイ
 resource "aws_internet_gateway" "main" {
   provider = aws.tokyo
   vpc_id   = aws_vpc.main.id
-  tags = {
-    Name = "terra-igw"
-  }
 }
 
 # Egress Only インターネットゲートウェイ
 resource "aws_egress_only_internet_gateway" "egress_only" {
   provider = aws.tokyo
   vpc_id   = aws_vpc.main.id
-  tags = {
-    Name = "terra-egress-only-igw"
-  }
 }
 
 # ルートテーブル
 resource "aws_route_table" "public" {
   provider = aws.tokyo
   vpc_id   = aws_vpc.main.id
-  tags = {
-    Name = "terra-rtb"
-  }
 }
 
 # インターネットへのIPv4ルート

--- a/s3.tf
+++ b/s3.tf
@@ -3,9 +3,6 @@ resource "aws_s3_bucket" "log" {
   provider      = aws.tokyo
   bucket        = "log-${var.app_domain}"
   force_destroy = true
-  tags = {
-    Name = "terra-log"
-  }
 }
 
 resource "aws_s3_bucket_ownership_controls" "log" {
@@ -26,9 +23,6 @@ resource "aws_s3_bucket" "image" {
   provider      = aws.tokyo
   bucket        = var.image_s3_bucket
   force_destroy = true
-  tags = {
-    Name = "terra-image"
-  }
 }
 
 resource "aws_s3_bucket_ownership_controls" "image" {

--- a/security.tf
+++ b/security.tf
@@ -3,9 +3,6 @@ resource "aws_security_group" "default" {
   provider = aws.tokyo
   vpc_id   = aws_vpc.main.id
   name     = "terra-default-sg"
-  tags = {
-    Name = "terra-default-sg"
-  }
 
   ingress {
     from_port = 0
@@ -27,9 +24,6 @@ resource "aws_security_group" "ec2" {
   provider = aws.tokyo
   vpc_id   = aws_vpc.main.id
   name     = "terra-ec2-sg"
-  tags = {
-    Name = "terra-ec2-sg"
-  }
 
   ingress {
     from_port        = 22
@@ -59,9 +53,6 @@ resource "aws_security_group" "elb" {
   provider = aws.tokyo
   vpc_id   = aws_vpc.main.id
   name     = "terra-elb-sg"
-  tags = {
-    Name = "terra-elb-sg"
-  }
 
   ingress {
     from_port        = 443


### PR DESCRIPTION
## 変更内容

- 8つのリソースファイルから計22箇所の `tags = { ... }` ブロックを削除
- `provider.tf` の `default_tags { ManagedBy = "Terraform" }` に一元化（変更なし）

対象ファイル: `loadbalancer.tf`, `network.tf`, `acm.tf`, `backend-resources.tf`, `compute.tf`, `s3.tf`, `cloudfront.tf`, `security.tf`

Close #23