### PR TITLE
Route53ホストゾーンをTerraformで作成するように変更

### DIFF
--- a/acm.tf
+++ b/acm.tf
@@ -22,7 +22,7 @@ resource "aws_route53_record" "tokyo_cert_validation" {
       record = dvo.resource_record_value
     }
   }
-  zone_id = data.aws_route53_zone.delegated.zone_id
+  zone_id = aws_route53_zone.delegated.zone_id
   name    = each.value.name
   type    = each.value.type
   records = [each.value.record]
@@ -59,7 +59,7 @@ resource "aws_route53_record" "image_cert_validation" {
       record = dvo.resource_record_value
     }
   }
-  zone_id = data.aws_route53_zone.delegated.zone_id
+  zone_id = aws_route53_zone.delegated.zone_id
   name    = each.value.name
   type    = each.value.type
   records = [each.value.record]

--- a/route53.tf
+++ b/route53.tf
@@ -1,12 +1,11 @@
-# Route53ゾーンIDを自動取得(ゾーン名から)
-data "aws_route53_zone" "delegated" {
-  name         = var.zone_domain
-  private_zone = false
+# Route53ホストゾーンを作成
+resource "aws_route53_zone" "delegated" {
+  name = var.zone_domain
 }
 
 # アプリケーションドメイン用Route53レコード(CloudFront用)
 resource "aws_route53_record" "app_cloudfront" {
-  zone_id = data.aws_route53_zone.delegated.zone_id
+  zone_id = aws_route53_zone.delegated.zone_id
   name    = var.app_domain
   type    = "A"
   alias {
@@ -18,7 +17,7 @@ resource "aws_route53_record" "app_cloudfront" {
 
 # Route53レコード(画像ドメイン用CloudFront・本番)
 resource "aws_route53_record" "image_cloudfront" {
-  zone_id = data.aws_route53_zone.delegated.zone_id
+  zone_id = aws_route53_zone.delegated.zone_id
   name    = var.image_domain
   type    = "A"
   alias {


### PR DESCRIPTION
## 変更内容

- `data "aws_route53_zone"` によるlookupを廃止し、`resource "aws_route53_zone"` でホストゾーンを作成するように変更
- `route53.tf` および `acm.tf` 内の参照を `data.aws_route53_zone.delegated.zone_id` から `aws_route53_zone.delegated.zone_id` に更新

Close #25