### PR TITLE
EC2に画像用S3への読み書き権限追加

### DIFF
--- a/modules/cloudfront-s3/main.tf
+++ b/modules/cloudfront-s3/main.tf
@@ -111,7 +111,7 @@ resource "aws_s3_bucket_policy" "image" {
         Principal = {
           Service = "cloudfront.amazonaws.com"
         }
-        Action = ["s3:GetObject"]
+        Action   = ["s3:GetObject"]
         Resource = "${var.s3_bucket_arn}/*"
         Condition = {
           StringEquals = {

--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -1,3 +1,43 @@
+# EC2用IAMロール
+resource "aws_iam_role" "ec2" {
+  name = "ec2-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+# 画像S3への読み書きポリシー
+resource "aws_iam_role_policy" "s3_image" {
+  name = "s3-image-policy"
+  role = aws_iam_role.ec2.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = "${var.image_s3_bucket_arn}/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = var.image_s3_bucket_arn
+      }
+    ]
+  })
+}
+
+# EC2にロールをアタッチするInstance Profile
+resource "aws_iam_instance_profile" "ec2" {
+  name = "ec2-instance-profile"
+  role = aws_iam_role.ec2.name
+}
+
 # EC2 Instance Connect Endpoint
 resource "aws_ec2_instance_connect_endpoint" "main" {
   subnet_id          = var.subnet_id
@@ -19,6 +59,7 @@ resource "aws_instance" "web" {
   associate_public_ip_address = false
   vpc_security_group_ids      = [var.default_sg_id, var.ec2_sg_id]
   key_name                    = aws_key_pair.main.key_name
+  iam_instance_profile        = aws_iam_instance_profile.ec2.name
   user_data                   = <<-EOF
     #!/bin/bash
     sudo dnf -y upgrade

--- a/modules/compute/variables.tf
+++ b/modules/compute/variables.tf
@@ -29,3 +29,8 @@ variable "ami" {
   type        = string
   default     = "ami-027fff96cc515f7bc" # Amazon Linux 2023 (ap-northeast-1)
 }
+
+variable "image_s3_bucket_arn" {
+  description = "ARN of the image S3 bucket for EC2 IAM policy"
+  type        = string
+}

--- a/prod/main.tf
+++ b/prod/main.tf
@@ -100,11 +100,12 @@ module "acm_image_virginia" {
 module "compute" {
   source = "../modules/compute"
 
-  subnet_id     = module.network.subnet_public_a_id
-  default_sg_id = module.security.default_sg_id
-  ec2_sg_id     = module.security.ec2_sg_id
-  public_key    = var.public_key
-  instance_type = var.instance_type
+  subnet_id           = module.network.subnet_public_a_id
+  default_sg_id       = module.security.default_sg_id
+  ec2_sg_id           = module.security.ec2_sg_id
+  public_key          = var.public_key
+  instance_type       = var.instance_type
+  image_s3_bucket_arn = module.image_s3.bucket_arn
 }
 
 module "loadbalancer" {

--- a/stg/main.tf
+++ b/stg/main.tf
@@ -100,11 +100,12 @@ module "acm_image_virginia" {
 module "compute" {
   source = "../modules/compute"
 
-  subnet_id     = module.network.subnet_public_a_id
-  default_sg_id = module.security.default_sg_id
-  ec2_sg_id     = module.security.ec2_sg_id
-  public_key    = var.public_key
-  instance_type = var.instance_type
+  subnet_id           = module.network.subnet_public_a_id
+  default_sg_id       = module.security.default_sg_id
+  ec2_sg_id           = module.security.ec2_sg_id
+  public_key          = var.public_key
+  instance_type       = var.instance_type
+  image_s3_bucket_arn = module.image_s3.bucket_arn
 }
 
 module "loadbalancer" {


### PR DESCRIPTION
## 変更内容

- `modules/compute` モジュールに EC2 用 IAM ロール・ポリシー・Instance Profile を追加
- EC2 インスタンスに `iam_instance_profile` をアタッチ
- 付与する権限: `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`（オブジェクト操作）、`s3:ListBucket`（バケット一覧）
- `stg/main.tf` と `prod/main.tf` の `module.compute` に `image_s3_bucket_arn` を追加

Close #37